### PR TITLE
Code fix based on new jest changes

### DIFF
--- a/chapter-10/higher-order-components/with-data.spec.js
+++ b/chapter-10/higher-order-components/with-data.spec.js
@@ -8,7 +8,7 @@ const List = () => <div />
 
 jest.mock('./get-json', () => {
   const data = 'data'
-  jest.fn(() => ({ then: callback => callback(data) }))
+  return jest.fn(() => ({ then: callback => callback(data) }))
 })
 
 test('passes the props to the component', () => {

--- a/chapter-10/higher-order-components/with-data.spec.js
+++ b/chapter-10/higher-order-components/with-data.spec.js
@@ -6,9 +6,10 @@ import getJSON from './get-json'
 const data = 'data'
 const List = () => <div />
 
-jest.mock('./get-json', () => (
+jest.mock('./get-json', () => {
+  const data = 'data'
   jest.fn(() => ({ then: callback => callback(data) }))
-))
+})
 
 test('passes the props to the component', () => {
   const ListWithGists = withData()(List)


### PR DESCRIPTION
based on FB GitHub trace  https://github.com/facebook/jest/issues/2567 you can't reference external data inside of mock function. You will get following error

The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables. 

To fix this you need to declare local variable instead